### PR TITLE
Add clang as a requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,12 +63,13 @@ While running, user can use following commands.
 
  - libpcap
  - libncurses
+ - clang
 
 We assume that users use Ubuntu. If you use another distribution, please change
 Package-Manager according to the environment.
 
 ```
-$ sudo apt install libpcap-dev libncurses5-dev
+$ sudo apt install libpcap-dev libncurses5-dev clang
 ```
 
 


### PR DESCRIPTION
Clang was also required to run make.
```
ebiken@lab:~/github/slankdev/cuishark$ make
CXX main.o
make: clang++: Command not found
make: *** [main.o] Error 127
ebiken@lab:~/github/slankdev/cuishark$ sudo apt install clang
ebiken@lab:~/github/slankdev/cuishark$ make
CXX main.o
CXX TuiFrontend.o
CXX TextPane.o
CXX PacketListPane.o
CXX ToggleListPane.o
CXX protocol.o
LD cuishark
ebiken@lab:~/github/slankdev/cuishark$
```