### PR TITLE
Honor DESTDIR and PREFIX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
-
-
+PREFIX = /usr/local
 
 CXX = g++
 CXXFLAGS += -Wall -Werror
@@ -34,6 +33,7 @@ clean:
 	rm -rf $(TARGET) *.o
 
 install:
-	cp $(TARGET) /usr/local/bin/$(TARGET)
+	mkdir -p $(DESTDIR)$(PREFIX)/bin
+	cp $(TARGET) $(DESTDIR)$(PREFIX)/bin/$(TARGET)
 
 


### PR DESCRIPTION
Hello, 
Although `/usr/local/bin` is often a good destination directory, it's more "friendly" and flexible to make use of PREFIX and DESTDIR.
That way if the user/packager want's to, he can change that destination.
PREFIX is also set to `/user/local/bin` by default so if the user just run `make install`, it will go there.

I haven't been able to test cuishark extensively yet, but it seems like a very handy tool to have ! Thanks !